### PR TITLE
Fix advanced headings

### DIFF
--- a/Advanced/carryall-adv-week1.html
+++ b/Advanced/carryall-adv-week1.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 1: Professional WHS & Risk Management</b></summary>
+  <summary><b>Week 1: Safety Scenarios</b></summary>
   <article>
-    <h4>Advanced Theory: Professional WHS & Risk Management</h4>
+    <h4>Advanced Theory: Safety Scenarios</h4>
     <p>Professional woodworking falls under the NSW Work Health and Safety Act 2011.  Every PCBU (Person Conducting a Business or Undertaking) must eliminate risks where reasonably practicable, using the Hierarchy of Controls—elimination, substitution, engineering controls, administration and finally PPE.  A formal risk‑assessment matrix compares likelihood against severity to set priorities.  Woodworking hazards include airborne dust, noise above 85 dB(A), kick‑back, moving blades and manual‑handling injuries.  Engineering controls like blade guards and local exhaust ventilation drastically reduce risk, while SDSs (Safety Data Sheets) outline dust exposure limits and emergency measures.</p>
 
     <form class="quiz" data-week="Week 1" id="adv-week1-quiz">

--- a/Advanced/carryall-adv-week10.html
+++ b/Advanced/carryall-adv-week10.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 10: Repair, Correction &amp; Professional Refinement</b></summary>
+  <summary><b>Week 10: Cutting Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Repair, Correction &amp; Professional Refinement</h4>
+    <h4>Advanced Theory: Cutting Scenario</h4>
     <p>Common post‑assembly corrections include scraping glue squeeze‑out with a card scraper sharpened to a 0.8 mm burr.  Slight twist (&lt;1 mm per 300 mm) can be planed out using winding sticks.  Butterfly (Dutchman) keys stabilise splits by adding cross‑grain shear resistance.  Heat guns at 70 °C soften cured PVA for joint disassembly.  Coloured toner in lacquer evens sapwood‑heartwood contrast; target Delta‑E colour variance &lt;3 for furniture‑grade panels.</p>
 
     <form class="quiz" data-week="Week 10" id="adv-week10-quiz">

--- a/Advanced/carryall-adv-week11.html
+++ b/Advanced/carryall-adv-week11.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 11: Parametric CAD &amp; Assembly Simulation</b></summary>
+  <summary><b>Week 11: CAD/CAM Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Parametric CAD &amp; Assembly Simulation</h4>
+    <h4>Advanced Theory: CAD/CAM Scenario</h4>
     <p>Advanced CAD leverages parametric constraints—dimensions driven by equations—allowing instant resizing of entire assemblies.  Assemblies use mates (coincident, concentric, gear) to simulate kinematics and perform interference detection.  Mass properties tools estimate centre of gravity.  Export formats such as STEP preserve solid data for cross‑platform CAM, while STL is mesh‑only.  Design‑for‑Manufacture Rule‑checks flag features smaller than tool diameters, and integrated BOM generators link directly to ERP systems.</p>
 
     <form class="quiz" data-week="Week 11" id="adv-week11-quiz">

--- a/Advanced/carryall-adv-week12.html
+++ b/Advanced/carryall-adv-week12.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 12: Toolpath Optimisation &amp; Post‑Processing</b></summary>
+  <summary><b>Week 12: Assembly Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Toolpath Optimisation &amp; Post‑Processing</h4>
+    <h4>Advanced Theory: Assembly Scenario</h4>
     <p>CAM software converts geometry into toolpaths.  Adaptive clearing maintains constant cutter engagement, lowering tool wear.  Feed rate (F) combines chip‑load and spindle speed (S).  Post‑processors output machine‑specific G/M codes; modal commands persist until changed.  Lead‑in arcs (G3) reduce cutter shock.  Tool length offset (G43) relies on accurate touch‑off probing.  High‑speed machining uses look‑ahead controllers to maintain corner quality at &gt;10 m min⁻¹.</p>
 
     <form class="quiz" data-week="Week 12" id="adv-week12-quiz">

--- a/Advanced/carryall-adv-week13.html
+++ b/Advanced/carryall-adv-week13.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 13: Statistical Quality Control &amp; Tolerance Analysis</b></summary>
+  <summary><b>Week 13: Finishing Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Statistical Quality Control &amp; Tolerance Analysis</h4>
+    <h4>Advanced Theory: Finishing Scenario</h4>
     <p>Quality Assurance (QA) deploys Statistical Process Control (SPC) charts—X‑bar and R—to monitor process variation.  Capability index Cpk &gt;1.33 indicates adequate centring and spread within specification limits.  Gauge R&amp;R measures repeatability and reproducibility of inspection tools; &lt;10 % variation is considered excellent.  Tolerance chains are analysed via RSS (root‑sum‑square) to predict assembly variation.  Digital calipers accuracy is ±0.02 mm; for critical features a CMM (coordinate‑measuring machine) may be required.</p>
 
     <form class="quiz" data-week="Week 13" id="adv-week13-quiz">

--- a/Advanced/carryall-adv-week14.html
+++ b/Advanced/carryall-adv-week14.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 14: Coating Technology &amp; Curing Systems</b></summary>
+  <summary><b>Week 14: Peer Review Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Coating Technology &amp; Curing Systems</h4>
+    <h4>Advanced Theory: Peer Review Scenario</h4>
     <p>Industrial finishes include UV‑cured acrylates, which polymerise in &lt;3 s under 365 nm lamps, achieving hardness &gt;H on the pencil scale.  Catalysed conversion varnish contains acid catalysts, providing high chemical resistance.  Transfer efficiency of HVLP spray guns can exceed 70 %.  Viscosity is measured with a Ford cup; temperature adjustment compensates for 2 % viscosity change per °C.  Orange‑peel defects result from improper atomisation or over‑thick film build.</p>
 
     <form class="quiz" data-week="Week 14" id="adv-week14-quiz">

--- a/Advanced/carryall-adv-week15.html
+++ b/Advanced/carryall-adv-week15.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 15: Portfolio Development &amp; Continuous Improvement</b></summary>
+  <summary><b>Week 15: Presentation Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Portfolio Development &amp; Continuous Improvement</h4>
+    <h4>Advanced Theory: Presentation Scenario</h4>
     <p>A professional portfolio documents project scope, technical drawings, LCA results, SPC data and high‑resolution photos.  Captions follow the STAR method—Situation, Task, Action, Result.  Continuous Professional Development (CPD) for trades may require 20 hours annually, tracked via logbook.  Reflective practice uses Gibbs’ cycle: Description, Feelings, Evaluation, Analysis, Conclusion, Action Plan.  Publishing case studies on platforms like Behance or LinkedIn builds professional presence.</p>
 
     <form class="quiz" data-week="Week 15" id="adv-week15-quiz">

--- a/Advanced/carryall-adv-week2.html
+++ b/Advanced/carryall-adv-week2.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 2: Indigenous Timber Technologies & Ethics</b></summary>
+  <summary><b>Week 2: Design Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Indigenous Timber Technologies & Ethics</h4>
+    <h4>Advanced Theory: Design Scenario</h4>
     <p>Aboriginal and Torres Strait Islander Peoples developed sophisticated timber technologies over tens of thousands of years, guided by deep ecological knowledge (often called Traditional Ecological Knowledge, TEK).  Harvesting followed cultural protocols—taking bark only in the right season and from healthy trees so they regrow.  Spinifex resin was used as a thermoplastic adhesive, reheated to repair tools.  Respectful use of Indigenous designs today requires genuine collaboration and acknowledgement of intellectual and cultural property rights.</p>
 
     <form class="quiz" data-week="Week 2" id="adv-week2-quiz">

--- a/Advanced/carryall-adv-week3.html
+++ b/Advanced/carryall-adv-week3.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 3: Timber Mechanics & Joint Strength</b></summary>
+  <summary><b>Week 3: Sketching Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Timber Mechanics & Joint Strength</h4>
+    <h4>Advanced Theory: Sketching Scenario</h4>
     <p>Radiata pine (Pinus radiata) used in the Carry‑all averages a Modulus of Elasticity (MOE) around 8–10 GPa and density near 550 kg m⁻³ at 12 % moisture content.  Tangential shrinkage from green to 12 % MC is ~6 %, so joints must allow for movement.  A dovetail joint gains strength from mechanical interlock, whereas a finger joint relies on large glue‑line area.  PVA adhesive develops full strength after water evaporation and wood‑cell penetration, achieving wood‑failure if properly clamped.</p>
 
     <form class="quiz" data-week="Week 3" id="adv-week3-quiz">

--- a/Advanced/carryall-adv-week4.html
+++ b/Advanced/carryall-adv-week4.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 4: CNC Production & Tolerance Control</b></summary>
+  <summary><b>Week 4: Materials Choice</b></summary>
   <article>
-    <h4>Advanced Theory: CNC Production & Tolerance Control</h4>
+    <h4>Advanced Theory: Materials Choice</h4>
     <p>In industrial production, parts are referenced to a single absolute coordinate system.  G‑code commands (e.g. G0 rapid, G1 linear feed) drive CNC routers to ±0.05 mm tolerance.  Tolerance stack‑up analysis ensures assembled boxes remain square when each side could be ±0.1 mm out.  Toolpaths balance feed speed and chip‑load to minimise burning and tear‑out while extending cutter life.  Finger‑jointing lines use automatic scanners to detect defects and optimise board layout.</p>
 
     <form class="quiz" data-week="Week 4" id="adv-week4-quiz">

--- a/Advanced/carryall-adv-week5.html
+++ b/Advanced/carryall-adv-week5.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 5: Timber Careers & Engineered Wood</b></summary>
+  <summary><b>Week 5: Measurement Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Timber Careers & Engineered Wood</h4>
+    <h4>Advanced Theory: Measurement Scenario</h4>
     <p>Timber careers span from Certificate III apprenticeships to degree‑level timber engineering.  Industry 4.0 technologies—robotic loading, IoT sensors, and cloud‑based production dashboards—are changing cabinetmaking and CLT manufacture.  Engineered products like Cross‑Laminated Timber (CLT) achieve out‑of‑plane bending stiffness comparable to steel at one‑fifth the density.  Bearing design values come from Australian Standard AS 1720.1.  A Level 1 cabinetmaker apprentice typically completes 3–4 years on‑the‑job training plus TAFE study.</p>
 
     <form class="quiz" data-week="Week 5" id="adv-week5-quiz">

--- a/Advanced/carryall-adv-week6.html
+++ b/Advanced/carryall-adv-week6.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 6: Life‑Cycle Analysis &amp; Carbon Accounting</b></summary>
+  <summary><b>Week 6: Joinery Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Life‑Cycle Analysis &amp; Carbon Accounting</h4>
+    <h4>Advanced Theory: Joinery Scenario</h4>
     <p>Life‑Cycle Assessment (LCA) measures environmental impacts of a product from raw material extraction to disposal.  Kiln‑dried softwood typically contains about 1.5 MJ kg⁻¹ embodied energy, compared with &gt;20 MJ kg⁻¹ for structural steel. One cubic metre of radiata pine stores roughly 0.9 t CO₂ for the life of the product.  Certification schemes such as FSC and PEFC provide Chain‑of‑Custody tracking.  Off‑cut optimisation software increases material yield by 15–30 %, supporting circular‑economy goals.</p>
 
     <form class="quiz" data-week="Week 6" id="adv-week6-quiz">

--- a/Advanced/carryall-adv-week7.html
+++ b/Advanced/carryall-adv-week7.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 7: Adhesive Chemistry &amp; Fastener Mechanics</b></summary>
+  <summary><b>Week 7: Hardware Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Adhesive Chemistry &amp; Fastener Mechanics</h4>
+    <h4>Advanced Theory: Hardware Scenario</h4>
     <p>Wood adhesives vary: PVA (poly‑vinyl acetate) cures by water diffusion, requiring clamp pressures around 0.7–1 N mm⁻².  Urea‑formaldehyde offers higher heat resistance; epoxies bond end‑grain and gap‑fill.  Pilot holes should be ~85 % of a screw’s root diameter to avoid splitting yet maximise withdrawal resistance, which is proportional to G·D¹·⁵·L (specific gravity × diameter^1.5 × length).  Clamp pressure distributes through cauls; excessive force can starve a joint of glue.</p>
 
     <form class="quiz" data-week="Week 7" id="adv-week7-quiz">

--- a/Advanced/carryall-adv-week8.html
+++ b/Advanced/carryall-adv-week8.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 8: Assembly Geometry &amp; Squareness Control</b></summary>
+  <summary><b>Week 8: Adhesives Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Assembly Geometry &amp; Squareness Control</h4>
+    <h4>Advanced Theory: Adhesives Scenario</h4>
     <p>Dry‑fit checks use diagonal measurements: if diagonals match within 1 mm, the box is square.  Racking forces are analysed as moments; a 2 mm diagonal error in a 300 mm frame produces ~0.38° skew.  Trammel points or story sticks transfer measurements without cumulative tape errors.  Moisture gradients across panel thickness can induce cupping; acclimating panels to workshop EMC minimises warping. High‑gap joints may be filled using epoxy plus micro‑balloons, but this is aesthetic—not structural.</p>
 
     <form class="quiz" data-week="Week 8" id="adv-week8-quiz">

--- a/Advanced/carryall-adv-week9.html
+++ b/Advanced/carryall-adv-week9.html
@@ -15,9 +15,9 @@
 <body>
 
 <details open>
-  <summary><b>Week 9: Surface Roughness &amp; Finishing Chemistry</b></summary>
+  <summary><b>Week 9: Clamping Scenario</b></summary>
   <article>
-    <h4>Advanced Theory: Surface Roughness &amp; Finishing Chemistry</h4>
+    <h4>Advanced Theory: Clamping Scenario</h4>
     <p>Surface roughness is quantified by Ra (μm).  Final hand‑sanding to 180–220 grit achieves Ra ≈ 3–5 μm, suitable for clear coats.  Water‑based polyurethane uses isocyanate‑free cross‑linkers, emits low VOCs (&lt;60 g L⁻¹) and cures by coalescence plus ambient moisture.  Grain‑raising can be pre‑treated by wiping with a damp cloth then re‑sanding.  Fillers contain silica or CaCO₃ to level pores; optimal film build is ~100 μm total in 3–4 thin coats.</p>
 
     <form class="quiz" data-week="Week 9" id="adv-week9-quiz">

--- a/index.html
+++ b/index.html
@@ -115,21 +115,21 @@
   <section class="content-section" id="advanced-activities" tabindex="0">
     <h2>Advanced Theory Content (Optional)</h2>
     <div class="accordion">
-      <details><summary>Week 1: Professional WHS &amp; Risk Management</summary><p><a href="Advanced%20New/carryall-adv-week1.html">View Week 1 Advanced</a></p></details>
-      <details><summary>Week 2: Indigenous Timber Technologies &amp; Ethics</summary><p><a href="Advanced%20New/carryall-adv-week2.html">View Week 2 Advanced</a></p></details>
-      <details><summary>Week 3: Timber Mechanics &amp; Joint Strength</summary><p><a href="Advanced%20New/carryall-adv-week3.html">View Week 3 Advanced</a></p></details>
-      <details><summary>Week 4: CNC Production &amp; Tolerance Control</summary><p><a href="Advanced%20New/carryall-adv-week4.html">View Week 4 Advanced</a></p></details>
-      <details><summary>Week 5: Timber Careers &amp; Engineered Wood</summary><p><a href="Advanced%20New/carryall-adv-week5.html">View Week 5 Advanced</a></p></details>
-      <details><summary>Week 6: Life&ndash;Cycle Analysis &amp; Carbon Accounting</summary><p><a href="Advanced%20New/carryall-adv-week6.html">View Week 6 Advanced</a></p></details>
-      <details><summary>Week 7: Adhesive Chemistry &amp; Fastener Mechanics</summary><p><a href="Advanced%20New/carryall-adv-week7.html">View Week 7 Advanced</a></p></details>
-      <details><summary>Week 8: Assembly Geometry &amp; Squareness Control</summary><p><a href="Advanced%20New/carryall-adv-week8.html">View Week 8 Advanced</a></p></details>
-      <details><summary>Week 9: Surface Roughness &amp; Finishing Chemistry</summary><p><a href="Advanced%20New/carryall-adv-week9.html">View Week 9 Advanced</a></p></details>
-      <details><summary>Week 10: Repair, Correction &amp; Professional Refinement</summary><p><a href="Advanced%20New/carryall-adv-week10.html">View Week 10 Advanced</a></p></details>
-      <details><summary>Week 11: Parametric CAD &amp; Assembly Simulation</summary><p><a href="Advanced%20New/carryall-adv-week11.html">View Week 11 Advanced</a></p></details>
-      <details><summary>Week 12: Toolpath Optimisation &amp; Post&#8209;Processing</summary><p><a href="Advanced%20New/carryall-adv-week12.html">View Week 12 Advanced</a></p></details>
-      <details><summary>Week 13: Statistical Quality Control &amp; Tolerance Analysis</summary><p><a href="Advanced%20New/carryall-adv-week13.html">View Week 13 Advanced</a></p></details>
-      <details><summary>Week 14: Coating Technology &amp; Curing Systems</summary><p><a href="Advanced%20New/carryall-adv-week14.html">View Week 14 Advanced</a></p></details>
-      <details><summary>Week 15: Portfolio Development &amp; Continuous Improvement</summary><p><a href="Advanced%20New/carryall-adv-week15.html">View Week 15 Advanced</a></p></details>
+      <details><summary>Week 1: Safety Scenarios</summary><p><a href="Advanced%20New/carryall-adv-week1.html">View Week 1 Advanced</a></p></details>
+      <details><summary>Week 2: Design Scenario</summary><p><a href="Advanced%20New/carryall-adv-week2.html">View Week 2 Advanced</a></p></details>
+      <details><summary>Week 3: Sketching Scenario</summary><p><a href="Advanced%20New/carryall-adv-week3.html">View Week 3 Advanced</a></p></details>
+      <details><summary>Week 4: Materials Choice</summary><p><a href="Advanced%20New/carryall-adv-week4.html">View Week 4 Advanced</a></p></details>
+      <details><summary>Week 5: Measurement Scenario</summary><p><a href="Advanced%20New/carryall-adv-week5.html">View Week 5 Advanced</a></p></details>
+      <details><summary>Week 6: Joinery Scenario</summary><p><a href="Advanced%20New/carryall-adv-week6.html">View Week 6 Advanced</a></p></details>
+      <details><summary>Week 7: Hardware Scenario</summary><p><a href="Advanced%20New/carryall-adv-week7.html">View Week 7 Advanced</a></p></details>
+      <details><summary>Week 8: Adhesives Scenario</summary><p><a href="Advanced%20New/carryall-adv-week8.html">View Week 8 Advanced</a></p></details>
+      <details><summary>Week 9: Clamping Scenario</summary><p><a href="Advanced%20New/carryall-adv-week9.html">View Week 9 Advanced</a></p></details>
+      <details><summary>Week 10: Cutting Scenario</summary><p><a href="Advanced%20New/carryall-adv-week10.html">View Week 10 Advanced</a></p></details>
+      <details><summary>Week 11: CAD/CAM Scenario</summary><p><a href="Advanced%20New/carryall-adv-week11.html">View Week 11 Advanced</a></p></details>
+      <details><summary>Week 12: Assembly Scenario</summary><p><a href="Advanced%20New/carryall-adv-week12.html">View Week 12 Advanced</a></p></details>
+      <details><summary>Week 13: Finishing Scenario</summary><p><a href="Advanced%20New/carryall-adv-week13.html">View Week 13 Advanced</a></p></details>
+      <details><summary>Week 14: Peer Review Scenario</summary><p><a href="Advanced%20New/carryall-adv-week14.html">View Week 14 Advanced</a></p></details>
+      <details><summary>Week 15: Presentation Scenario</summary><p><a href="Advanced%20New/carryall-adv-week15.html">View Week 15 Advanced</a></p></details>
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- sync index with new scenario-based headings
- rename advanced theory headings to match scenario themes

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879fc3ffc9c83269160d5e0237f31ee