### PR TITLE
Fix quiz submission buttons for weeks 5–15

### DIFF
--- a/week10.html
+++ b/week10.html
@@ -7,33 +7,12 @@
   <title>Week 10 – Troubleshooting & Refinement</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '1', q3: '3', q4: '2', q5: '1',
-        q6: '3', q7: '2', q8: '3', q9: '2', q10: '4'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent =
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 10', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "1", q3: "3", q4: "2", q5: "1",
+    q6: "3", q7: "2", q8: "3", q9: "2", q10: "4"
+  };
 </script>
 
 </head>
@@ -154,7 +133,7 @@
             <label><input type="radio" name="q10" value="4"> 6</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M010',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week11.html
+++ b/week11.html
@@ -7,33 +7,12 @@
   <title>Week 11 – Handles, Hardware & Functional Design</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '2', q3: '3', q4: '3', q5: '3',
-        q6: '3', q7: '2', q8: '2', q9: '3', q10: '2'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent =
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 11', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "2", q3: "3", q4: "3", q5: "3",
+    q6: "3", q7: "2", q8: "2", q9: "3", q10: "2"
+  };
 </script>
 
 </head>
@@ -152,7 +131,7 @@
             <label><input type="radio" name="q10" value="4"> Screwing directly into any surface</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M011',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week12.html
+++ b/week12.html
@@ -7,33 +7,12 @@
   <title>Week 12 – Staining & Varnishing Techniques</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '3', q3: '1', q4: '2', q5: '3',
-        q6: '2', q7: '1', q8: '3', q9: '2', q10: '2'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent =
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 12', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "3", q3: "1", q4: "2", q5: "3",
+    q6: "2", q7: "1", q8: "3", q9: "2", q10: "2"
+  };
 </script>
 
 </head>
@@ -155,7 +134,7 @@
             <label><input type="radio" name="q10" value="4"> Cover with plastic</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M012',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week13.html
+++ b/week13.html
@@ -7,33 +7,12 @@
   <title>Week 13 – Project Finalisation & Quality Assurance</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '3', q2: '2', q3: '1', q4: '3', q5: '2',
-        q6: '1', q7: '3', q8: '2', q9: '1', q10: '2'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent =
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 13', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "3", q2: "2", q3: "1", q4: "3", q5: "2",
+    q6: "1", q7: "3", q8: "2", q9: "1", q10: "2"
+  };
 </script>
 
 </head>
@@ -155,7 +134,7 @@
             <label><input type="radio" name="q10" value="4"> Sanding corners randomly</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M013',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week14.html
+++ b/week14.html
@@ -7,30 +7,9 @@
   <title>Week 14 – Peer Feedback & Final Refinements</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = { q1: '4', q2: '2', q3: '2', q4: '2', q5: '4' };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent =
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 14', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = { q1: "4", q2: "2", q3: "2", q4: "2", q5: "4" };
 </script>
 
 </head>
@@ -109,7 +88,7 @@
             <label><input type="radio" name="q5" value="4"> To skip sanding</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M014',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week15.html
+++ b/week15.html
@@ -7,30 +7,9 @@
   <title>Week 15 – Course Reflection &amp; Next Steps</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {"q1":"2","q2":"1","q3":"3","q4":"2","q5":"4","q6":"1","q7":"2","q8":"3","q9":"1","q10":"2"};
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('result').textContent =
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 15', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {"q1":"2","q2":"1","q3":"3","q4":"2","q5":"4","q6":"1","q7":"2","q8":"3","q9":"1","q10":"2"};
 </script>
 
 </head>
@@ -144,7 +123,7 @@
             <label><input type="radio" name="q10" value="4"> Only practice sanding</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M015',answers)">Check Answers</button>
         <span id="result" class="quiz-msg"></span>
       </form>
     </section>

--- a/week5.html
+++ b/week5.html
@@ -7,33 +7,12 @@
   <title>Week 5 – Timber Careers & Technology</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '2', q3: '2', q4: '3', q5: '3',
-        q6: '4', q7: '2', q8: '2', q9: '3', q10: '2'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent = 
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 5', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "2", q3: "2", q4: "3", q5: "3",
+    q6: "4", q7: "2", q8: "2", q9: "3", q10: "2"
+  };
 </script>
 
 </head>
@@ -155,7 +134,7 @@
             <label><input type="radio" name="q10" value="4"> Year 12 certificate with ATAR</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M005',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week6.html
+++ b/week6.html
@@ -7,33 +7,12 @@
   <title>Week 6 – Timber, Sustainability & Smart Design</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '3', q2: '2', q3: '3', q4: '3', q5: '2',
-        q6: '3', q7: '3', q8: '2', q9: '3', q10: '3'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent = 
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 6', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "3", q2: "2", q3: "3", q4: "3", q5: "2",
+    q6: "3", q7: "3", q8: "2", q9: "3", q10: "3"
+  };
 </script>
 
 </head>
@@ -151,7 +130,7 @@
             <label><input type="radio" name="q10" value="4"> Sharing offcuts with classmates</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M006',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week7.html
+++ b/week7.html
@@ -6,33 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Week 7 – Fasteners, Adhesives & Holding Techniques</title>
   <link rel="stylesheet" href="carryall.css">
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '2', q3: '3', q4: '2', q5: '2',
-        q6: '3', q7: '3', q8: '2', q9: '2', q10: '2'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent = 
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 7', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "2", q3: "3", q4: "2", q5: "2",
+    q6: "3", q7: "3", q8: "2", q9: "2", q10: "2"
+  };
 </script>
 
 </head>
@@ -141,7 +120,7 @@
             <label><input type="radio" name="q10" value="4"> It sharpens your tools automatically</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M007',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week8.html
+++ b/week8.html
@@ -7,33 +7,12 @@
   <title>Week 8 – Assembly, Squareness & Dry Fitting Techniques</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '3', q3: '3', q4: '2', q5: '2',
-        q6: '2', q7: '2', q8: '1', q9: '2', q10: '3'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent = 
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 8', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "3", q3: "3", q4: "2", q5: "2",
+    q6: "2", q7: "2", q8: "1", q9: "2", q10: "3"
+  };
 </script>
 
 </head>
@@ -164,7 +143,7 @@
             <label><input type="radio" name="q10" value="4"> Glue quickly</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M008',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>

--- a/week9.html
+++ b/week9.html
@@ -7,33 +7,12 @@
   <title>Week 9 – Sanding, Finishing & Surface Prep</title>
   <link rel="stylesheet" href="carryall.css">
   
+<script src="quiz-submit.js"></script>
 <script>
-    function submitQuiz() {
-      const name = document.getElementById('studentName').value.trim();
-      if (!name) {
-        alert('Please enter your name.');
-        return;
-      }
-      const answers = {
-        q1: '2', q2: '3', q3: '2', q4: '3', q5: '2',
-        q6: '3', q7: '2', q8: '3', q9: '3'
-      };
-      let correct = 0;
-      const total = Object.keys(answers).length;
-      for (let q in answers) {
-        const sel = document.querySelector('input[name="' + q + '"]:checked');
-        if (sel && sel.value === answers[q]) correct++;
-      }
-      document.getElementById('quizResult').textContent = 
-        `Thanks ${name}, you scored ${correct}/${total}.`;
-      fetch('https://script.google.com/macros/s/AKfycbzF-svt49mb0H23s8YPNVMyq-ELWzWVf6zJsaIQqN8vf6Rz8d9jGezj-4da_il3prw3/exec', {
-        method: 'POST',
-        mode: 'no-cors',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: name, week: 'Week 9', score: correct })
-      });
-      alert('Your mark has been submitted to your teacher');
-    }
+  const answers = {
+    q1: "2", q2: "3", q3: "2", q4: "3", q5: "2",
+    q6: "3", q7: "2", q8: "3", q9: "3"
+  };
 </script>
 
 </head>
@@ -141,7 +120,7 @@
             <label><input type="radio" name="q9" value="4"> Chalk pastel</label>
           </li>
         </ol>
-        <button type="button" onclick="submitQuiz()">Check Answers</button>
+        <button type="button" onclick="submitQuiz(this,'M009',answers)">Check Answers</button>
         <span id="quizResult" class="quiz-msg"></span>
       </form>
     </section>


### PR DESCRIPTION
## Summary
- load shared `quiz-submit.js` in weekly quiz pages 5-15
- replace old inline submission logic and attach proper `submitQuiz` calls with quiz IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893e3c722288326875ad07fe876befa